### PR TITLE
composerの初期設定

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN /bin/cp -f /usr/share/zoneinfo/Asia/Tokyo /etc/localtime \
  ca-certificates curl git zip jq bc vim \
  python python-yaml \
  python-pip python-dev libffi-dev \
- libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng12-dev libtidy-dev libssl-dev \
+ libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng12-dev libtidy-dev libssl-dev libicu-dev \
  \
  && apt-get -y --purge remove python-cffi \
  \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NAME      := generic-build
 REGISTRY  := whiteplus/$(NAME)
-VERSION   := 20170617
+VERSION   := 20170926
 
 .PHONY: build push
 

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -18,5 +18,7 @@
     - include_vars:
         file: vars/lang.yml
         name: lang
+    - include_vars: vars/composer_global_packages.yml
     - include: tasks/anyenv.yml
     - include: tasks/circleci.yml
+    - include: tasks/composer.yml

--- a/ansible/tasks/composer.yml
+++ b/ansible/tasks/composer.yml
@@ -1,0 +1,18 @@
+- name: Update composer
+  shell: |
+      export PATH=~/.anyenv/envs/phpenv/shims:$PATH
+      composer self-update --no-ansi --no-interaction --no-progress
+  register: composer_update
+  changed_when: "'Updating to version' in composer_update.stdout"
+  args:
+      executable: /bin/bash
+
+- name: Setup mirror for composer packages
+  shell: |
+      export PATH=~/.anyenv/envs/phpenv/shims:$PATH
+      composer config --global --no-ansi --no-interaction repositories.packagist composer https://packagist.jp
+  args:
+      executable: /bin/bash
+
+- include: composer_global_require.yml
+  when: composer_global_packages|length > 0

--- a/ansible/tasks/composer_global_require.yml
+++ b/ansible/tasks/composer_global_require.yml
@@ -1,0 +1,9 @@
+- name: Install configured composer globally-required packages
+  shell: |
+      export PATH=~/.anyenv/envs/phpenv/shims:$PATH
+      composer global require --no-ansi --no-interaction {{ item.name }}:{{ item.release | default('@stable') }}
+  args:
+      executable: /bin/bash
+      creates: ~/.anyenv/envs/phpenv/versions/{{ lang.php.version }}/composer/vendor/{{ item.name }}
+  with_items: "{{ composer_global_packages }}"
+

--- a/ansible/vars/composer_global_packages.yml
+++ b/ansible/vars/composer_global_packages.yml
@@ -1,0 +1,6 @@
+# A list of packages to install globally. See commented examples below for
+# usage; the 'release' is optional, and defaults to '@stable'.
+composer_global_packages:
+  # - { name: 'phpunit/phpunit', release: '4.7.x' }
+  # - { name: 'phpunit/phpunit', release: '@stable' }
+  - { name: 'hirak/prestissimo', release: '^0.3' }


### PR DESCRIPTION
# 概要

- composerの初期設定のタスクを追加

# レビューのポイント

- anyenvでphpenvをインストールするとデフォルトでngyuki/phpenv-composerがインストールされるので、個別でのcomposerのインストールは不要でした

- phpenvのインストールでエラーが出ていたので、解消するためにlibicu-devを追加しました
  - エラー内容：
    `"configure: error: Unable to detect ICU prefix or no failed. Please verify ICU install prefix and make sure icu-config works.", `
  - CircleCIでPHPが動いているのはなんでなんだろう…？

- ansible的に環境変数をどこで通すのがきれいなのかよくわかってないので、とりあえず個別にshellモジュールでexportしてます
  - まずかったら全体を見直すタイミングで直しちゃってくださいmm

- composecrモジュールがまともに動かなかったのでshellモジュールを使ってます